### PR TITLE
[Schedule] Change the bool value returned by scheduleCall in Schedule to bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ function getPrice(address token) public view returns (uint256, uint256);
 - ScheduleCall contract address: `0x0000000000000000000000000000000000000803`
 ```
 // Schedule call the contract.
-// Returns a boolean value indicating whether the operation succeeded.
-function scheduleCall(address contract_address, uint256 value, uint256 gas_limit, uint256 storage_limit, uint256 min_delay, bytes memory input_data) public returns (bool);
+// Returns a bytes value equal to the task_id of the task created.
+function scheduleCall(address contract_address, uint256 value, uint256 gas_limit, uint256 storage_limit, uint256 min_delay, bytes memory input_data) public returns (bytes memory);
 
 // Cancel schedule call the contract.
 // Returns a boolean value indicating whether the operation succeeded.

--- a/contracts/schedule/ISchedule.sol
+++ b/contracts/schedule/ISchedule.sol
@@ -16,7 +16,7 @@ interface ISchedule {
         bytes calldata input_data // The input data to the call.
     )
     external
-    returns (bool); // Returns a boolean value indicating whether the operation succeeded.
+    returns (bytes memory); // Returns a bytes value equal to the task_id of the task created.
 
     // Cancel schedule call the contract.
     // Returns a boolean value indicating whether the operation succeeded.

--- a/contracts/schedule/Schedule.sol
+++ b/contracts/schedule/Schedule.sol
@@ -5,7 +5,7 @@ import "./ISchedule.sol";
 contract Schedule is ISchedule {
     /**
      * @dev Schedule call the contract.
-     * Returns a boolean value indicating whether the operation succeeded.
+     * Returns a bytes value equal to the task_id of the task created.
      */
     function scheduleCall(
         address contract_address,
@@ -14,7 +14,7 @@ contract Schedule is ISchedule {
         uint256 storage_limit,
         uint256 min_delay,
         bytes memory input_data
-    ) public override returns (bool) {
+    ) public override returns (bytes memory) {
         require(contract_address != address(0), "ScheduleCall: the contract_address is the zero address");
         require(input_data.length > 0, "ScheduleCall: input is null");
 
@@ -40,7 +40,7 @@ contract Schedule is ISchedule {
         }
 
         emit ScheduledCall(msg.sender, contract_address, task_id);
-        return true;
+        return task_id;
     }
 
     /**


### PR DESCRIPTION
Value returned by the `scheduleCall()` function in `Schedule` used to be
`bool`, signifying the successful execution of the function. This commit
changes it to the `bytes` value that is equal to `task_id` of the task
created by calling the function. This way the smart contracts calling
the `Schedule` smart contract are able to provide even more automation in
regards to interacting with the `Schedule` smart contract.

For example:
The user does not need to note the `task_id` by themselves, the smart contract
can automatically save it for them and they can implement the `cancelCall` or
`rescheduleCall` easier without having to input the `task_id`.