### PR TITLE
Add typescript to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "handlebars": "^4.7.7"
   },
   "devDependencies": {
-    "truffle": "^5.1.50"
+    "truffle": "^5.1.50",
+    "typescript": "^4.4.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,6 +1271,11 @@ truffle@^5.1.50:
     mocha "8.1.2"
     original-require "1.0.1"
 
+typescript@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
+  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
+
 uglify-js@^3.1.4:
   version "3.12.8"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.12.8.tgz#a82e6e53c9be14f7382de3d068ef1e26e7d4aaf8"


### PR DESCRIPTION
When running 'yarn generate-bytecode', the process would fail, because
typescript was not added as a development dependency.

This PR addresses issue #64 